### PR TITLE
Verbesserung, so dass die Objekte nicht nach links gezogen werden

### DIFF
--- a/Collision/Collision/Program.cs
+++ b/Collision/Collision/Program.cs
@@ -65,7 +65,7 @@ namespace ConsoleApplication1
                     //Schaut ob es sich bereits ganz oben befindet
                     if (posy == 0)  //wenn, dann springt es einfach auf der gegenüberliegenden Seite wieder ein(ganz unten)
                     {
-                        posy = seite;
+                        posy = seite - 1;
                     }
                     else  //wenn nicht, dann ganz normal eine Zelle nach oben
                     {
@@ -76,7 +76,7 @@ namespace ConsoleApplication1
                 if (Richtung == 2)
                 {
                     //Schaut ob es sich bereits ganz unten befindet
-                    if (posy == seite) //wenn, dann springt es einfach auf der gegenüberliegenden Seite wieder ein(ganz oben)
+                    if (posy == seite - 1) //wenn, dann springt es einfach auf der gegenüberliegenden Seite wieder ein(ganz oben)
                     {
                         posy = 0;
                     }
@@ -91,7 +91,7 @@ namespace ConsoleApplication1
                     //Schaut ob es sich bereits ganz links befindet
                     if (posx == 0)  //wenn, dann springt es einfach auf der gegenüberliegenden Seite wieder ein(ganz rechts)
                     {
-                        posx = seite;
+                        posx = seite - 1;
                     }
                     else  //wenn nicht, einfach ganz normal eine Zelle nach links
                     {
@@ -103,7 +103,7 @@ namespace ConsoleApplication1
                 if (Richtung == 4)
                 {
                     //Schaut ob es sich bereits ganz rechts befindet
-                    if (posx == seite)//wenn, dann springt es einfach auf der gegenüberliegenden Seite wieder ein(ganz links)
+                    if (posx == seite - 1)//wenn, dann springt es einfach auf der gegenüberliegenden Seite wieder ein(ganz links)
                     {
                         posx = 0;
                     }

--- a/Collision/Collision/Program.cs
+++ b/Collision/Collision/Program.cs
@@ -63,9 +63,9 @@ namespace ConsoleApplication1
                 if (Richtung == 1)
                 {
                     //Schaut ob es sich bereits ganz oben befindet
-                    if (posy == 0)  //wenn, dann geht es einfach eine Zelle in die andere Richtung(runter)
+                    if (posy == 0)  //wenn, dann springt es einfach auf der gegenüberliegenden Seite wieder ein(ganz unten)
                     {
-                        posy++;
+                        posy = seite;
                     }
                     else  //wenn nicht, dann ganz normal eine Zelle nach oben
                     {
@@ -76,9 +76,9 @@ namespace ConsoleApplication1
                 if (Richtung == 2)
                 {
                     //Schaut ob es sich bereits ganz unten befindet
-                    if (posy == seite) //wenn, dann geht es einfach eine Zelle in die andere Richtung(hoch)
+                    if (posy == seite) //wenn, dann springt es einfach auf der gegenüberliegenden Seite wieder ein(ganz oben)
                     {
-                        posy--;
+                        posy = 0;
                     }
                     else  //wenn nicht, einfach ganz normal eine Zelle nach unten
                     {
@@ -89,9 +89,9 @@ namespace ConsoleApplication1
                 if (Richtung == 3)
                 {
                     //Schaut ob es sich bereits ganz links befindet
-                    if (posx == 0)  //wenn, dann geht es einfach eine Zelle in die andere Richtung(rechts)
+                    if (posx == 0)  //wenn, dann springt es einfach auf der gegenüberliegenden Seite wieder ein(ganz rechts)
                     {
-                        posx++;
+                        posx = seite;
                     }
                     else  //wenn nicht, einfach ganz normal eine Zelle nach links
                     {
@@ -103,9 +103,9 @@ namespace ConsoleApplication1
                 if (Richtung == 4)
                 {
                     //Schaut ob es sich bereits ganz rechts befindet
-                    if (posx == seite)//wenn, dann geht es einfach eine Zelle in die andere Richtung(links)
+                    if (posx == seite)//wenn, dann springt es einfach auf der gegenüberliegenden Seite wieder ein(ganz links)
                     {
-                        posx--;
+                        posx = 0;
                     }
                     else  //wenn nicht, einfach ganz normal eine Zelle nach rechts
                     {


### PR DESCRIPTION
Wenn ein Objekt am Rand ist, und die zufällige Richtung weiter in diese Richtung geht, dann geht es nicht mehr wie vorher eine Zelle in die andere Richtung, sondern springt auf der gegenüberliegenden Seite wieder ein.